### PR TITLE
change expressGraphQL to graphqlHTTP

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const expressGraphQL = require('express-graphql');
+const { graphqlHTTP } = require('express-graphql');
 const schema = require('./schema.js');
 const cors = require('cors');
 
@@ -8,7 +8,7 @@ const app = express();
 // enable `cors` to set HTTP response header: Access-Control-Allow-Origin: *
 app.use(cors());
 
-app.use('/graphql', expressGraphQL({
+app.use('/graphql', graphqlHTTP({
     schema:schema,
     graphiql:true
 }));


### PR DESCRIPTION
```require('express-graphql')```  returns an object with a property called ```graphqlHTTP``` that is the function you want to call.